### PR TITLE
Correct <openssl/hmac.h> include (case mismatch).

### DIFF
--- a/jtr_plugin/sandcrypt_fmt_plug.c
+++ b/jtr_plugin/sandcrypt_fmt_plug.c
@@ -20,7 +20,7 @@
 
 #include <openssl/opensslv.h>
 #include <openssl/evp.h>
-#include <openssl/HMAC.h>
+#include <openssl/hmac.h>
 #if OPENSSL_VERSION_NUMBER >= 0x00908000
 
 #include <string.h>


### PR DESCRIPTION
I believe most distros libssl-dev provide 'hmac.h' instead of 'HMAC.h'.  Please consider this patch for merging upstream as it fixes compilation issues of 'sandcrypt_fmt_plug.c' on numerous platforms.
